### PR TITLE
Fix fatal error in php8.3 with propel reverse

### DIFF
--- a/generator/lib/task/PropelSchemaReverseTask.php
+++ b/generator/lib/task/PropelSchemaReverseTask.php
@@ -518,7 +518,7 @@ class PropelSchemaReverseTask extends PDOTask
         $msg = self::$validatorMessages[strtolower($type)];
         $tmp = compact($msg['var']);
         array_unshift($tmp, $msg['msg']);
-        $msg = call_user_func_array('sprintf', $tmp);
+        $msg = call_user_func_array('sprintf', array_values($tmp));
 
         return $msg;
     }


### PR DESCRIPTION
fix "PHP Fatal error:  Uncaught ArgumentCountError: sprintf() does not accept unknown named parameters" (php83)